### PR TITLE
[GCT-1384] Added support for build from dist in all envs

### DIFF
--- a/jakelib/deploy.jake
+++ b/jakelib/deploy.jake
@@ -94,7 +94,7 @@ namespace('deploy', function () {
     },
     consumer: {
       cmds: [
-        './node_modules/.bin/gulp {{cluster_name}}-build',
+        './node_modules/.bin/gulp {{cluster_name}}-dist',
         'docker build -t {{cluster_name}}-{{app_name}} . --no-cache',
         'docker tag {{cluster_name}}-{{app_name}}:latest 052248958630.dkr.ecr.us-west-2.amazonaws.com/{{cluster_name}}-{{app_name}}:latest',
         'docker push 052248958630.dkr.ecr.us-west-2.amazonaws.com/{{cluster_name}}-{{app_name}}:latest',
@@ -204,7 +204,7 @@ namespace('deploy', function () {
 
   desc('Deploy all shipping services (shipping-api, shipping-worker, shipping-scheduler) to ECS. | [cluster_name]');
   task('shipping', ['aws:loadCredentials'], { async: false }, function(cluster_name) {
-   
+
     const services = [
       'shipping-api',
       'shipping-worker',


### PR DESCRIPTION
Companion to https://github.com/greenchef/app-greenchef/pull/734.

Just makes our app deploys run against the new `dist` options.